### PR TITLE
[ROSBOARD] [FIX]: Changed publisher destroyer to prevent errors.

### DIFF
--- a/rosboard/handlers.py
+++ b/rosboard/handlers.py
@@ -194,11 +194,13 @@ class ROSBoardSocketHandler(tornado.websocket.WebSocketHandler):
                 return
             topic_name = argv[1].get("topicName")
 
-            if topic_name not in self.node.local_pubs:
-                self.node.local_pubs[topic_name] = set()
-
             try:
-                self.node.local_pubs[topic_name].unregister()
+                if topic_name not in self.node.local_pubs:
+                    print("WARN: Attempted to remove unavailable topic.")
+                else:
+                    self.node.local_pubs[topic_name].unregister()
+                    self.node.local_pubs.pop(topic_name)
+            
             except KeyError:
                 print("KeyError trying to remove publisher")
 


### PR DESCRIPTION
After adding the feature of destroying a publisher when the client-to-server stream is closed, some errors started to popup. Such errors occurred when a given topic is streamed from the client to the server, its connection is closed and then the streaming is started again. 

![image](https://user-images.githubusercontent.com/14006555/183447007-596f86c6-8eec-4133-8321-779e36476b0f.png)

This PR includes a minor change that solves this bug in the server side. It can be tested by streaming the same topic from the client to the server and closing the connection multiple times.