### PR TITLE
Option to send topics on demand and full typedefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ They are a great project, I initially used it, but moved away from it in favor o
 
 * `port` - The port to run the web server on. Default is 8888.
 * `resize_images` - Resize images if they are larger than 800 pixels in either dimension. Default is true.
+* `max_allowed_latency` - Maximum allowed latency in milliseconds before dropping the connection. Default is 10000.
+* `foxglove_uri` - URI of the Foxglove Studio instance to redirect to when the "Foxglove" button is clicked. Default is official Foxglove Studio instance https://app.foxglove.dev/ **which doesn't work with the rosboard protocol**. You can run your own Foxglove Studio instance and set this parameter accordingly. Our foxglove fork supports this protocol.
+* `foxglove_layout_uri` - public URI to the Foxglove Studio layout to be used in the Foxglove Studio instance. Default is empty, which means the default layout will be used. **Note**: this is not supported by the official Foxglove Studio instance.
 
+These 2 last parameters are only available in our fork of Foxglove Studio. Refer to https://github.com/kiwicampus/studio/tree/kiwi-main?tab=readme-ov-file#connecting-to-rosboard
 
 ## Credits
 

--- a/rosboard/handlers.py
+++ b/rosboard/handlers.py
@@ -9,10 +9,9 @@ import tornado
 import tornado.web
 import tornado.websocket
 
+from rosboard.topics import get_all_topics, get_all_topics_with_typedef
+
 from . import __version__
-
-from rosboard.topics import get_all_topics_with_typedef, get_all_topics
-
 
 
 class MainPageHandler(tornado.web.RequestHandler):
@@ -176,6 +175,11 @@ class ROSBoardSocketHandler(tornado.websocket.WebSocketHandler):
 
             topic_name = argv[1].get("topicName")
             max_update_rate = float(argv[1].get("maxUpdateRate", 24.0))
+
+            # topic_type = get_all_topics().get(topic_name)
+            # if topic_type is not None and topic_type == 'sensor_msgs/msg/PointCloud2':
+            #     max_update_rate = 5.0
+            #     print("PointCloud2 topic detected, setting max update rate to 5.0")
 
             self.update_intervals_by_topic[topic_name] = 1.0 / max_update_rate
             self.node.update_intervals_by_topic[topic_name] = min(

--- a/rosboard/handlers.py
+++ b/rosboard/handlers.py
@@ -25,9 +25,10 @@ class ROSBoardSocketHandler(tornado.websocket.WebSocketHandler):
         # Allow connections from any origin so we can connect from other pages
         return True
 
-    def initialize(self, node):
+    def initialize(self, node, max_allowed_latency):
         # store the instance of the ROS node that created this WebSocketHandler so we can access it later
         self.node = node
+        self.max_allowed_latency = max_allowed_latency
 
     def get_compression_options(self):
         # Non-None enables compression with default options.
@@ -150,8 +151,9 @@ class ROSBoardSocketHandler(tornado.websocket.WebSocketHandler):
             if self.latency > 1000.0:
                 self.node.logwarn("socket %s has high latency of %.2f ms" % (str(self.id), self.latency))
             
-            if self.latency > 10000.0:
+            if self.latency > self.max_allowed_latency:
                 self.node.logerr("socket %s has excessive latency of %.2f ms; closing connection" % (str(self.id), self.latency))
+                self.node.logerr("max allowed latency is %.2f ms" % self.max_allowed_latency)
                 self.close()
 
         # client wants to subscribe to topic

--- a/rosboard/handlers.py
+++ b/rosboard/handlers.py
@@ -13,10 +13,22 @@ from . import __version__
 
 from rosboard.topics import get_all_topics_with_typedef, get_all_topics
 
-class NoCacheStaticFileHandler(tornado.web.StaticFileHandler):
+
+
+class MainPageHandler(tornado.web.RequestHandler):
+
+    def get(self, path=None):
+        self.render(self.default_filename, foxglove_uri=self.foxglove_uri, foxglove_layout_uri=self.foxglove_layout_uri)
+
     def set_extra_headers(self, path):
         # Disable cache
         self.set_header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+
+    def initialize(self, default_filename, foxglove_uri, foxglove_layout_uri):
+        self.default_filename = default_filename
+        self.foxglove_uri = foxglove_uri
+        self.foxglove_layout_uri = foxglove_layout_uri
+
 
 class ROSBoardSocketHandler(tornado.websocket.WebSocketHandler):
     sockets = set()

--- a/rosboard/handlers.py
+++ b/rosboard/handlers.py
@@ -124,7 +124,7 @@ class ROSBoardSocketHandler(tornado.websocket.WebSocketHandler):
         Message received from the client.
         """
 
-        if self.ws_connection.is_closing():
+        if self.ws_connection is None or self.ws_connection.is_closing():
             return
 
         # JSON decode it, give up if it isn't valid JSON

--- a/rosboard/html/index.html
+++ b/rosboard/html/index.html
@@ -1,59 +1,88 @@
 <!doctype html>
 <html>
-    <head>
-      <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
-        <link href="css/material-icons.css" media="all" rel="stylesheet" type="text/css">
-        <script type="text/javascript" src="js/jquery-3.1.0.min.js" integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="></script>
-        <link rel="stylesheet" href="css/material.indigo-blue.min.css" />
-        <link rel="stylesheet" href="css/uPlot.min.css">
-        <link rel="stylesheet" href="css/leaflet.css">
-        <link href="css/index.css" media="all" rel="stylesheet" type="text/css">
-        
-        <script type="text/javascript" src="js/json5.min.js"></script>
-        <script type="text/javascript" src="js/uPlot.iife.min.js"></script>
-        <script type="text/javascript" src="js/jquery.transit.min.js"></script>
-        <script type="text/javascript" src="js/masonry.pkgd.min.js"></script>
-        <script type="text/javascript" src="js/eventemitter2.min.js"></script>
-        <script text="text/javascript" src="js/import-helper.js"></script>
-        <script type="text/javascript" src="js/material.min.js" defer></script>
-        <script type="text/javascript" src="js/leaflet.js"></script>        
-	      <script type="text/javascript" src="js/gl-matrix.js"></script>
-	      <script type="text/javascript" src="js/litegl.min.js"></script>
-        <script type="text/javascript" src="js/index.js" defer></script>
 
-        <title>ROSboard</title>
-    </head>
-    <body>
-        <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
-          <header class="mdl-layout__header">
-            <div class="mdl-layout__header-row">
-              <!-- Title -->
-              <span class="mdl-layout-title">ROSboard</span>
-              <!-- Add spacer, to align navigation to the right -->
-              <div class="mdl-layout-spacer"></div>
-            </div>
-          </header>
-          <div class="mdl-layout__drawer">
-            <nav id="topics-nav" class="mdl-navigation">
-                <div id="topics-nav-system-title" class="topics-nav-title">System</div>
-                <div id="topics-nav-system"></div>
-                <div id="topics-nav-ros-title" class="topics-nav-title">ROS topics</div>
-                <div id="topics-nav-ros"></div>
-                <div style="opacity:0.3;" id="topics-nav-unsupported"></div>
-            </nav>
-          </div>
-          <main class="mdl-layout__content">
-            <div class="page-content">
-              <div class="grid">
-              </div>
-            </div>
-          </main>
+<head>
+  <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
+  <link href="css/material-icons.css" media="all" rel="stylesheet" type="text/css">
+  <script type="text/javascript" src="js/jquery-3.1.0.min.js"
+    integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="></script>
+  <link rel="stylesheet" href="css/material.indigo-blue.min.css" />
+  <link rel="stylesheet" href="css/uPlot.min.css">
+  <link rel="stylesheet" href="css/leaflet.css">
+  <link href="css/index.css" media="all" rel="stylesheet" type="text/css">
+
+  <script type="text/javascript" src="js/json5.min.js"></script>
+  <script type="text/javascript" src="js/uPlot.iife.min.js"></script>
+  <script type="text/javascript" src="js/jquery.transit.min.js"></script>
+  <script type="text/javascript" src="js/masonry.pkgd.min.js"></script>
+  <script type="text/javascript" src="js/eventemitter2.min.js"></script>
+  <script text="text/javascript" src="js/import-helper.js"></script>
+  <script type="text/javascript" src="js/material.min.js" defer></script>
+  <script type="text/javascript" src="js/leaflet.js"></script>
+  <script type="text/javascript" src="js/gl-matrix.js"></script>
+  <script type="text/javascript" src="js/litegl.min.js"></script>
+  <script type="text/javascript" src="js/index.js" defer></script>
+
+  <title>ROSboard</title>
+</head>
+
+<body>
+  <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
+    <header class="mdl-layout__header">
+      <div class="mdl-layout__header-row">
+        <!-- Title -->
+        <span class="mdl-layout-title">ROSboard</span>
+        <!-- Add spacer, to align navigation to the right -->
+        <div class="mdl-layout-spacer"></div>
+        <!-- Foxglove redirect button -->
+        <button id="redirectButton"
+          class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
+          Connect with foxglove
+        </button>
+      </div>
+    </header>
+    <div class="mdl-layout__drawer">
+      <nav id="topics-nav" class="mdl-navigation">
+        <div id="topics-nav-system-title" class="topics-nav-title">System</div>
+        <div id="topics-nav-system"></div>
+        <div id="topics-nav-ros-title" class="topics-nav-title">ROS topics</div>
+        <div id="topics-nav-ros"></div>
+        <div style="opacity:0.3;" id="topics-nav-unsupported"></div>
+      </nav>
+    </div>
+    <main class="mdl-layout__content">
+      <div class="page-content">
+        <div class="grid">
         </div>
-        
+      </div>
+    </main>
+  </div>
+
   <div id="demo-toast-example" class="mdl-js-snackbar mdl-snackbar">
     <div class="mdl-snackbar__text"></div>
     <button class="mdl-snackbar__action" type="button"></button>
   </div>
 
-    </body>
+  <script>
+    document.getElementById('redirectButton').onclick = function () {
+      // Injected value from server
+      var foxglove_uri = "{{ foxglove_uri }}";
+      var foxglove_layout_uri = "{{ foxglove_layout_uri }}"
+      var host = window.location.host;
+      var protocol = window.location.protocol;
+      var secure = protocol === 'https:';
+      var websocket_url = 'ws' + (secure ? 's' : '') + '://' + host + '/rosboard/v1';
+      // Encode the path to make it a valid query URL string
+      websocket_url = encodeURIComponent(websocket_url);
+      var target_url = foxglove_uri + '?ds=rosboard-websocket&ds.url=' + websocket_url;
+      if (foxglove_layout_uri) {
+        foxglove_layout_uri = encodeURIComponent(foxglove_layout_uri);
+        target_url += '&layoutUrl=' + foxglove_layout_uri;
+      }
+      window.location.href = target_url;
+    };
+  </script>
+
+</body>
+
 </html>

--- a/rosboard/html/index.html
+++ b/rosboard/html/index.html
@@ -1,63 +1,60 @@
 <!doctype html>
 <html>
+    <head>
+      <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
+        <link href="css/material-icons.css" media="all" rel="stylesheet" type="text/css">
+        <script type="text/javascript" src="js/jquery-3.1.0.min.js" integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="></script>
+        <link rel="stylesheet" href="css/material.indigo-blue.min.css" />
+        <link rel="stylesheet" href="css/uPlot.min.css">
+        <link rel="stylesheet" href="css/leaflet.css">
+        <link href="css/index.css" media="all" rel="stylesheet" type="text/css">
+        
+        <script type="text/javascript" src="js/json5.min.js"></script>
+        <script type="text/javascript" src="js/uPlot.iife.min.js"></script>
+        <script type="text/javascript" src="js/jquery.transit.min.js"></script>
+        <script type="text/javascript" src="js/masonry.pkgd.min.js"></script>
+        <script type="text/javascript" src="js/eventemitter2.min.js"></script>
+        <script text="text/javascript" src="js/import-helper.js"></script>
+        <script type="text/javascript" src="js/material.min.js" defer></script>
+        <script type="text/javascript" src="js/leaflet.js"></script>        
+	      <script type="text/javascript" src="js/gl-matrix.js"></script>
+	      <script type="text/javascript" src="js/litegl.min.js"></script>
+        <script type="text/javascript" src="js/index.js" defer></script>
 
-<head>
-  <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
-  <link href="css/material-icons.css" media="all" rel="stylesheet" type="text/css">
-  <script type="text/javascript" src="js/jquery-3.1.0.min.js"
-    integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="></script>
-  <link rel="stylesheet" href="css/material.indigo-blue.min.css" />
-  <link rel="stylesheet" href="css/uPlot.min.css">
-  <link rel="stylesheet" href="css/leaflet.css">
-  <link href="css/index.css" media="all" rel="stylesheet" type="text/css">
-
-  <script type="text/javascript" src="js/json5.min.js"></script>
-  <script type="text/javascript" src="js/uPlot.iife.min.js"></script>
-  <script type="text/javascript" src="js/jquery.transit.min.js"></script>
-  <script type="text/javascript" src="js/masonry.pkgd.min.js"></script>
-  <script type="text/javascript" src="js/eventemitter2.min.js"></script>
-  <script text="text/javascript" src="js/import-helper.js"></script>
-  <script type="text/javascript" src="js/material.min.js" defer></script>
-  <script type="text/javascript" src="js/leaflet.js"></script>
-  <script type="text/javascript" src="js/gl-matrix.js"></script>
-  <script type="text/javascript" src="js/litegl.min.js"></script>
-  <script type="text/javascript" src="js/index.js" defer></script>
-
-  <title>ROSboard</title>
-</head>
-
-<body>
-  <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
-    <header class="mdl-layout__header">
-      <div class="mdl-layout__header-row">
-        <!-- Title -->
-        <span class="mdl-layout-title">ROSboard</span>
-        <!-- Add spacer, to align navigation to the right -->
-        <div class="mdl-layout-spacer"></div>
+        <title>ROSboard</title>
+    </head>
+    <body>
+        <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
+          <header class="mdl-layout__header">
+            <div class="mdl-layout__header-row">
+              <!-- Title -->
+              <span class="mdl-layout-title">ROSboard</span>
+              <!-- Add spacer, to align navigation to the right -->
+              <div class="mdl-layout-spacer"></div>
         <!-- Foxglove redirect button -->
         <button id="redirectButton"
           class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
           Connect with foxglove
         </button>
-      </div>
-    </header>
-    <div class="mdl-layout__drawer">
-      <nav id="topics-nav" class="mdl-navigation">
-        <div id="topics-nav-system-title" class="topics-nav-title">System</div>
-        <div id="topics-nav-system"></div>
-        <div id="topics-nav-ros-title" class="topics-nav-title">ROS topics</div>
-        <div id="topics-nav-ros"></div>
-        <div style="opacity:0.3;" id="topics-nav-unsupported"></div>
-      </nav>
-    </div>
-    <main class="mdl-layout__content">
-      <div class="page-content">
-        <div class="grid">
+            </div>
+          </header>
+          <div class="mdl-layout__drawer">
+            <nav id="topics-nav" class="mdl-navigation">
+                <div id="topics-nav-system-title" class="topics-nav-title">System</div>
+                <div id="topics-nav-system"></div>
+                <div id="topics-nav-ros-title" class="topics-nav-title">ROS topics</div>
+                <div id="topics-nav-ros"></div>
+                <div style="opacity:0.3;" id="topics-nav-unsupported"></div>
+            </nav>
+          </div>
+          <main class="mdl-layout__content">
+            <div class="page-content">
+              <div class="grid">
+              </div>
+            </div>
+          </main>
         </div>
-      </div>
-    </main>
-  </div>
-
+        
   <div id="demo-toast-example" class="mdl-js-snackbar mdl-snackbar">
     <div class="mdl-snackbar__text"></div>
     <button class="mdl-snackbar__action" type="button"></button>
@@ -83,6 +80,5 @@
     };
   </script>
 
-</body>
-
+    </body>
 </html>

--- a/rosboard/ros_init.py
+++ b/rosboard/ros_init.py
@@ -1,0 +1,9 @@
+import os
+
+if os.environ.get("ROS_VERSION") == "1":
+    import rospy  # ROS1
+elif os.environ.get("ROS_VERSION") == "2":
+    import rosboard.rospy2 as rospy  # ROS2
+else:
+    print("ROS not detected. Please source your ROS environment\n(e.g. 'source /opt/ros/$ROS_DISTRO/setup.bash')")
+    exit(1)

--- a/rosboard/rosboard.py
+++ b/rosboard/rosboard.py
@@ -31,6 +31,7 @@ class ROSBoardNode(object):
         rospy.init_node(node_name)
         self.port = rospy.get_param("~port", 8888)
         self.resize_images = rospy.get_param("~resize_images", True)
+        self.max_allowed_latency = rospy.get_param("~max_allowed_latency", 10000)
 
         # desired subscriptions of all the websockets connecting to this instance.
         # these remote subs are updated directly by "friend" class ROSBoardSocketHandler.
@@ -69,6 +70,7 @@ class ROSBoardNode(object):
         tornado_handlers = [
                 (r"/rosboard/v1", ROSBoardSocketHandler, {
                     "node": self,
+                    "max_allowed_latency": self.max_allowed_latency
                 }),
                 (r"/(.*)", NoCacheStaticFileHandler, {
                     "path": tornado_settings.get("static_path"),

--- a/rosboard/rosboard.py
+++ b/rosboard/rosboard.py
@@ -16,7 +16,7 @@ from rosboard.ros_init import rospy
 from rclpy_message_converter.message_converter import convert_dictionary_to_ros_message
 from rosgraph_msgs.msg import Log
 
-from rosboard.handlers import NoCacheStaticFileHandler, ROSBoardSocketHandler
+from rosboard.handlers import MainPageHandler, ROSBoardSocketHandler
 from rosboard.serialization import ros2dict
 from rosboard.subscribers.dmesg_subscriber import DMesgSubscriber
 from rosboard.subscribers.dummy_subscriber import DummySubscriber
@@ -32,7 +32,8 @@ class ROSBoardNode(object):
         self.port = rospy.get_param("~port", 8888)
         self.resize_images = rospy.get_param("~resize_images", True)
         self.max_allowed_latency = rospy.get_param("~max_allowed_latency", 10000)
-
+        self.foxglove_uri = rospy.get_param("~foxglove_uri", "https://app.foxglove.dev/")
+        self.foxglove_layout_uri = rospy.get_param("~foxglove_layout_uri", "")
         # desired subscriptions of all the websockets connecting to this instance.
         # these remote subs are updated directly by "friend" class ROSBoardSocketHandler.
         # this class will read them and create actual ROS subscribers accordingly.
@@ -62,9 +63,11 @@ class ROSBoardNode(object):
             # ros2 docs don't explain why but we need this magic.
             self.sub_rosout = rospy.Subscriber("/rosout", Log, lambda x:x)
 
+        static_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'html')
         tornado_settings = {
             'debug': True, 
-            'static_path': os.path.join(os.path.dirname(os.path.realpath(__file__)), 'html')
+            'static_path':static_path,
+            'template_path':static_path
         }
 
         tornado_handlers = [
@@ -72,10 +75,14 @@ class ROSBoardNode(object):
                     "node": self,
                     "max_allowed_latency": self.max_allowed_latency
                 }),
-                (r"/(.*)", NoCacheStaticFileHandler, {
-                    "path": tornado_settings.get("static_path"),
-                    "default_filename": "index.html"
+                (r"/", MainPageHandler, {
+                    "default_filename": "index.html",
+                    "foxglove_uri": self.foxglove_uri,
+                    "foxglove_layout_uri": self.foxglove_layout_uri
                 }),
+                (r"/js/(.*)", tornado.web.StaticFileHandler, {"path": os.path.join(static_path, 'js')}),
+                (r"/css/(.*)", tornado.web.StaticFileHandler, {"path": os.path.join(static_path, 'css')}),
+                (r"/fonts/(.*)", tornado.web.StaticFileHandler, {"path": os.path.join(static_path, 'fonts')}),
         ]
 
         self.event_loop = None

--- a/rosboard/topics.py
+++ b/rosboard/topics.py
@@ -1,0 +1,60 @@
+from rosidl_adapter.parser import parse_message_string
+from rosidl_runtime_py import get_interface_path
+
+from rosboard.ros_init import rospy
+
+def get_all_topics():
+    all_topics = {}
+    for topic_tuple in rospy.get_published_topics():
+        topic_name = topic_tuple[0]
+        topic_type = topic_tuple[1]
+        if type(topic_type) is list:
+            topic_type = topic_type[0] # ROS2
+        all_topics[topic_name] = topic_type
+    return all_topics
+
+def get_all_topics_with_typedef():
+    topics = get_all_topics()
+    full_topics = {}
+    for topic_name, topic_type in topics.items():
+        full_typedef = get_typedef_full_text(topic_type)
+        full_topics[topic_name] = {"type": topic_type, "typedef": full_typedef}
+    return full_topics
+
+def get_typedef_full_text(ty):
+    """Returns the full text (similar to `gendeps --cat`) for the specified message type"""
+    try:
+        return stringify_field_types(ty)
+    except Exception as e:
+        return f"# failed to get full definition text for {ty}: {str(e)}"
+    
+# Taken from https://github.com/RobotWebTools/rosbridge_suite/blob/7d78af16d30d0ffe232abcc65d0928ce90bd61f7/rosapi/src/rosapi/stringify_field_types.py#L5
+def stringify_field_types(root_type):
+    definition = ""
+    seen_types = set()
+    deps = [root_type]
+    is_root = True
+    while deps:
+        ty = deps.pop()
+        parts = ty.split("/")
+        if not is_root:
+            definition += "\n================================================================================\n"
+            definition += f"MSG: {ty}\n"
+        is_root = False
+
+        msg_name = parts[2] if len(parts) == 3 else parts[1]
+        interface_name = ty if len(parts) == 3 else f"{parts[0]}/msg/{parts[1]}"
+        with open(get_interface_path(interface_name), encoding="utf-8") as msg_file:
+            msg_definition = msg_file.read()
+        definition += msg_definition
+
+        spec = parse_message_string(parts[0], msg_name, msg_definition)
+        for field in spec.fields:
+            is_builtin = field.type.pkg_name is None
+            if not is_builtin:
+                field_ty = f"{field.type.pkg_name}/{field.type.type}"
+                if field_ty not in seen_types:
+                    deps.append(field_ty)
+                    seen_types.add(field_ty)
+
+    return definition

--- a/rosboard/topics.py
+++ b/rosboard/topics.py
@@ -1,8 +1,10 @@
 import os
+
 from rosidl_adapter.parser import parse_message_string
 from rosidl_runtime_py import get_interface_path
 
 from rosboard.ros_init import rospy
+
 
 def get_all_topics():
     all_topics = {}
@@ -14,6 +16,19 @@ def get_all_topics():
         all_topics[topic_name] = topic_type
     return all_topics
 
+def update_all_topics_with_typedef(full_topics, topics=None):
+    if topics is None:
+        topics = get_all_topics()
+    topic_names = set(topics.keys())
+    cached_topic_names = set(full_topics.keys())
+    # Get only the topics that are not cached
+    missing_topics = topic_names - cached_topic_names
+    if missing_topics:
+        for topic_name in missing_topics:
+            topic_type = topics[topic_name]
+            type_def = get_typedef_full_text(topic_type)
+            full_topics[topic_name] = {"type": topic_type, "typedef": type_def}
+
 def get_all_topics_with_typedef():
     topics = get_all_topics()
     full_topics = {}
@@ -22,6 +37,7 @@ def get_all_topics_with_typedef():
         full_topics[topic_name] = {"type": topic_type, "typedef": full_typedef}
     return full_topics
 
+# TODO: Add ros1 support for this function
 def get_typedef_full_text(ty):
     """Returns the full text (similar to `gendeps --cat`) for the specified message type"""
     try:

--- a/rosboard/topics.py
+++ b/rosboard/topics.py
@@ -1,3 +1,4 @@
+import os
 from rosidl_adapter.parser import parse_message_string
 from rosidl_runtime_py import get_interface_path
 
@@ -27,8 +28,27 @@ def get_typedef_full_text(ty):
         return stringify_field_types(ty)
     except Exception as e:
         return f"# failed to get full definition text for {ty}: {str(e)}"
+
+def extract_msg_path_from_idl(idl_path):
+    with open(idl_path, 'r', encoding='utf-8') as idl_file:
+        idl_content = idl_file.read()
     
+    # Try to extract the original .msg file path from content. Usually in the first lines
+    # there is a part that says "// with input from <path>" and path is related to the original .msg file
+    msg_file_info = [line for line in idl_content.split('\n') if '// with input from' in line]
+    if msg_file_info:
+        msg_path = msg_file_info[0].split('// with input from')[-1].strip()
+        # Remove "msg/" from the path, since the actual path doesn't have it
+        msg_path = msg_path.replace('msg/', '')
+        # Find parent directory of the idl just before the share folder
+        share_dir = idl_path.split('share')[0]
+        # Construct the full path to the .msg file
+        return os.path.join(share_dir, 'share', msg_path)
+    
+    return idl_path
+
 # Taken from https://github.com/RobotWebTools/rosbridge_suite/blob/7d78af16d30d0ffe232abcc65d0928ce90bd61f7/rosapi/src/rosapi/stringify_field_types.py#L5
+# Modified to account custom message types
 def stringify_field_types(root_type):
     definition = ""
     seen_types = set()
@@ -44,7 +64,15 @@ def stringify_field_types(root_type):
 
         msg_name = parts[2] if len(parts) == 3 else parts[1]
         interface_name = ty if len(parts) == 3 else f"{parts[0]}/msg/{parts[1]}"
-        with open(get_interface_path(interface_name), encoding="utf-8") as msg_file:
+
+        # Try to get the .msg file first
+        msg_path = get_interface_path(interface_name)
+
+        # If custom we get instead the .idl implementation
+        if msg_path.endswith('.idl'):
+            msg_path = extract_msg_path_from_idl(msg_path)
+
+        with open(msg_path, encoding="utf-8") as msg_file:
             msg_definition = msg_file.read()
         definition += msg_definition
 


### PR DESCRIPTION
Added:
* Option to the client to ask for the topics as they are sent in the heartbeat
* Option to the clients to ask for the full topics which means it gets sent the topic types and their full text type definitions like rosbridge_suite does. It returns a JSON where the keys are the topics and as value has another JSON with the keys `type` and `typedef`,  the latter referring to the full-text definition.