### PR TITLE
Send the correct encoding so other tools can visualize them properly

### DIFF
--- a/rosboard/compression.py
+++ b/rosboard/compression.py
@@ -237,6 +237,16 @@ def compress_occupancy_grid(msg, output):
     except OSError as e:
         output["_error"] = str(e)
 
+def adapt_encoding(encoding_str):
+    # Because we convert everything to uint8 and RGB/grayscale
+    # We need to adapt all encodings either to rgb8 or mono8
+    # Refer to https://github.com/ros/common_msgs/blob/noetic-devel/sensor_msgs/include/sensor_msgs/image_encodings.h
+    if "C1" in encoding_str or "mono" in encoding_str:
+        return "mono8"
+    else:
+        return "rgb8"
+
+
 DATATYPE_MAPPING_PCL2_NUMPY = {
     1: np.int8,
     2: np.uint8,

--- a/rosboard/serialization.py
+++ b/rosboard/serialization.py
@@ -44,6 +44,15 @@ def ros2dict(msg, resize_image:bool=True):
             rosboard.compression.compress_image(msg, output,resize_image=resize_image)
             continue
 
+        # Image/CompressedImage: adapt encoding
+        if (msg.__module__ in ("sensor_msgs.msg._Image", "sensor_msgs.msg._image") or \
+            msg.__module__ in ("sensor_msgs.msg._CompressedImage", "sensor_msgs.msg._compressed_image")) \
+            and field == "encoding":
+            # Because rosboard converts everything to uint8 RGB/Grayscale we need to adapt the encoding
+            encoding = rosboard.compression.adapt_encoding(msg.encoding)
+            output["encoding"] = encoding
+            continue
+
         # OccupancyGrid: render and compress to jpeg
         if (msg.__module__ == "nav_msgs.msg._OccupancyGrid" or \
             msg.__module__ == "nav_msgs.msg._occupancy_grid") \


### PR DESCRIPTION
Fixes https://github.com/kiwicampus/studio/issues/7
Because rosboard converts everything to uint8 and RGB/grayscale we need to adapt all encodings either to rgb8 or mono8